### PR TITLE
[refactor] 강아지 생성/ 강아지 주인전화번호로 조회/ 강아지 진료기록 추가 함수에 MongoDB적용

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,10 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
-
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-mongodb</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>

--- a/src/main/java/org/cnu/realcoding/controller/DogController.java
+++ b/src/main/java/org/cnu/realcoding/controller/DogController.java
@@ -5,6 +5,8 @@ import org.cnu.realcoding.service.DogService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 public class DogController {
 
@@ -19,7 +21,7 @@ public class DogController {
 
     /* 조회 */
     @GetMapping("/dogs/ownerPhoneNumber/{ownerPhoneNumber}")
-    public Dog getDogByOwnerPhoneNumber(@PathVariable String ownerPhoneNumber) {
+    public List<Dog> getDogByOwnerPhoneNumber(@PathVariable String ownerPhoneNumber) {
         return dogService.getDogByOwnerPhoneNumber(ownerPhoneNumber);
     }
 

--- a/src/main/java/org/cnu/realcoding/controller/DogController.java
+++ b/src/main/java/org/cnu/realcoding/controller/DogController.java
@@ -26,9 +26,14 @@ public class DogController {
     }
 
     /* 수정 */
-    @PatchMapping("/dogs/records/name/{name}")
-    public Dog modifyWithAddingDogRecord(@PathVariable String name, @RequestBody Dog dog) {
-        return dogService.modifyWithAddingDogRecord(name, dog.getMedicalRecords());
+    @PatchMapping("/dogs/records/name/{name}/ownerName/{ownerName}/ownerPhoneNumber/{ownerPhoneNumber}")
+    public Dog modifyWithAddingDogRecord(
+            @PathVariable String name,
+            @PathVariable String ownerName,
+            @PathVariable String ownerPhoneNumber,
+            @RequestBody Dog dog
+    ) {
+        return dogService.modifyWithAddingDogRecord(name, ownerName, ownerPhoneNumber, dog.getMedicalRecords());
     }
 }
 

--- a/src/main/java/org/cnu/realcoding/controller/DogController.java
+++ b/src/main/java/org/cnu/realcoding/controller/DogController.java
@@ -12,19 +12,19 @@ public class DogController {
     private DogService dogService;
 
     /* 삽입 */
-    @PostMapping("/dog")
+    @PostMapping("/dogs")
     public void createDog(@RequestBody Dog dog) {
         dogService.insertDog(dog);
     }
 
     /* 조회 */
-    @GetMapping("/dog/ownerPhoneNumber/{ownerPhoneNumber}")
+    @GetMapping("/dogs/ownerPhoneNumber/{ownerPhoneNumber}")
     public Dog getDogByOwnerPhoneNumber(@PathVariable String ownerPhoneNumber) {
         return dogService.getDogByOwnerPhoneNumber(ownerPhoneNumber);
     }
 
     /* 수정 */
-    @PatchMapping("/dog/records/name/{name}")
+    @PatchMapping("/dogs/records/name/{name}")
     public Dog modifyWithAddingDogRecord(@PathVariable String name, @RequestBody Dog dog) {
         return dogService.modifyWithAddingDogRecord(name, dog.getMedicalRecords());
     }

--- a/src/main/java/org/cnu/realcoding/exception/DogConflictException.java
+++ b/src/main/java/org/cnu/realcoding/exception/DogConflictException.java
@@ -1,0 +1,9 @@
+package org.cnu.realcoding.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.CONFLICT)
+public class DogConflictException extends RuntimeException{
+
+}

--- a/src/main/java/org/cnu/realcoding/exception/DogNotFoundException.java
+++ b/src/main/java/org/cnu/realcoding/exception/DogNotFoundException.java
@@ -7,3 +7,4 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 @ResponseStatus(HttpStatus.NOT_FOUND)
 public class DogNotFoundException extends RuntimeException{
 }
+

--- a/src/main/java/org/cnu/realcoding/repository/DogRepository.java
+++ b/src/main/java/org/cnu/realcoding/repository/DogRepository.java
@@ -18,13 +18,24 @@ public class DogRepository {
     private MongoTemplate mongoTemplate;
 
     /* 삽입 */
-    public void insertDog(Dog dog) {
-        mongoTemplate.insert(dog);
+    public Boolean insertDog(Dog dog) {
+        Query query = new Query().addCriteria(
+                Criteria.where("name").is(dog.getName())
+                        .and("ownerName").is(dog.getOwnerName())
+                        .and("ownerPhoneNumber").is(dog.getOwnerPhoneNumber())
+        );
+
+        Boolean dogExists = mongoTemplate.findOne(query, Dog.class) != null;
+        if (!dogExists) {
+            mongoTemplate.insert(dog);
+            return true;
+        }
+        return false;
     }
 
     /* 조회 */
-    public Dog getDogByOwnerPhoneNumber(String ownerPhoneNumber) {
-        return mongoTemplate.findOne(
+    public List<Dog> getDogByOwnerPhoneNumber(String ownerPhoneNumber) {
+        return mongoTemplate.find(
                 Query.query(Criteria.where("ownerPhoneNumber").is(ownerPhoneNumber)),
                 Dog.class
         );

--- a/src/main/java/org/cnu/realcoding/repository/DogRepository.java
+++ b/src/main/java/org/cnu/realcoding/repository/DogRepository.java
@@ -1,6 +1,5 @@
 package org.cnu.realcoding.repository;
 
-import com.mongodb.client.result.UpdateResult;
 import org.cnu.realcoding.domain.Dog;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.mongodb.core.MongoTemplate;
@@ -42,8 +41,12 @@ public class DogRepository {
     }
 
     /* 수정 */
-    public Dog modifyWithAddingDogRecord(String name, List<String> newRecords) {
-        Query query = new Query().addCriteria(Criteria.where("name").is(name));
+    public Dog modifyWithAddingDogRecord(String name, String ownerName, String ownerPhoneNumber, List<String> newRecords) {
+        Query query = new Query().addCriteria(
+                Criteria.where("name").is(name)
+                        .and("ownerName").is(ownerName)
+                        .and("ownerPhoneNumber").is(ownerPhoneNumber)
+        );
         Update update = new Update().push("medicalRecords").each(newRecords);
         return mongoTemplate.findAndModify(query, update, Dog.class);
     }

--- a/src/main/java/org/cnu/realcoding/repository/DogRepository.java
+++ b/src/main/java/org/cnu/realcoding/repository/DogRepository.java
@@ -1,6 +1,10 @@
 package org.cnu.realcoding.repository;
 
 import org.cnu.realcoding.domain.Dog;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.ArrayList;
@@ -10,17 +14,20 @@ import java.util.List;
 public class DogRepository {
     private List<Dog> dogs = new ArrayList<>();
 
+    @Autowired
+    private MongoTemplate mongoTemplate;
+
     /* 삽입 */
     public void insertDog(Dog dog) {
-        dogs.add(dog);
+        mongoTemplate.insert(dog);
     }
 
     /* 조회 */
     public Dog getDogByOwnerPhoneNumber(String ownerPhoneNumber) {
-        return dogs.stream()
-                .filter(dog -> dog.getOwnerPhoneNumber().equals(ownerPhoneNumber))
-                .findFirst()
-                .orElse(null);
+        return mongoTemplate.findOne(
+                Query.query(Criteria.where("ownerPhoneNumber").is(ownerPhoneNumber)),
+                Dog.class
+        );
     }
 
     /* 수정 */

--- a/src/main/java/org/cnu/realcoding/repository/DogRepository.java
+++ b/src/main/java/org/cnu/realcoding/repository/DogRepository.java
@@ -1,18 +1,18 @@
 package org.cnu.realcoding.repository;
 
+import com.mongodb.client.result.UpdateResult;
 import org.cnu.realcoding.domain.Dog;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.stereotype.Repository;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @Repository
 public class DogRepository {
-    private List<Dog> dogs = new ArrayList<>();
 
     @Autowired
     private MongoTemplate mongoTemplate;
@@ -32,17 +32,8 @@ public class DogRepository {
 
     /* 수정 */
     public Dog modifyWithAddingDogRecord(String name, List<String> newRecords) {
-        for(Dog dog: dogs) {
-            if(dog.getName().equals(name)) {
-                List<String> oldRecords = dog.getMedicalRecords();
-                List<String> records = new ArrayList<>();
-                records.addAll(oldRecords);
-                records.addAll(newRecords);
-
-                dog.setMedicalRecords(records);
-                return dog;
-            }
-        }
-        return null;
+        Query query = new Query().addCriteria(Criteria.where("name").is(name));
+        Update update = new Update().push("medicalRecords").each(newRecords);
+        return mongoTemplate.findAndModify(query, update, Dog.class);
     }
 }

--- a/src/main/java/org/cnu/realcoding/repository/DogRepository.java
+++ b/src/main/java/org/cnu/realcoding/repository/DogRepository.java
@@ -18,7 +18,7 @@ public class DogRepository {
 
     /* 삽입 */
     public Boolean insertDog(Dog dog) {
-        Query query = new Query().addCriteria(
+        Query query = new Query(
                 Criteria.where("name").is(dog.getName())
                         .and("ownerName").is(dog.getOwnerName())
                         .and("ownerPhoneNumber").is(dog.getOwnerPhoneNumber())

--- a/src/main/java/org/cnu/realcoding/service/DogService.java
+++ b/src/main/java/org/cnu/realcoding/service/DogService.java
@@ -33,8 +33,13 @@ public class DogService {
     }
 
     /* 수정 */
-    public Dog modifyWithAddingDogRecord(String name, List<String> newRecords) {
-        Dog dog = dogRepository.modifyWithAddingDogRecord(name, newRecords);
+    public Dog modifyWithAddingDogRecord(
+            String name,
+            String ownerName,
+            String ownerPhoneNumber,
+            List<String> newRecords
+    ) {
+        Dog dog = dogRepository.modifyWithAddingDogRecord(name, ownerName, ownerPhoneNumber, newRecords);
         if(dog == null) {
             throw new DogNotFoundException();
         }

--- a/src/main/java/org/cnu/realcoding/service/DogService.java
+++ b/src/main/java/org/cnu/realcoding/service/DogService.java
@@ -1,6 +1,7 @@
 package org.cnu.realcoding.service;
 
 import org.cnu.realcoding.domain.Dog;
+import org.cnu.realcoding.exception.DogConflictException;
 import org.cnu.realcoding.exception.DogNotFoundException;
 import org.cnu.realcoding.repository.DogRepository;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,16 +17,19 @@ public class DogService {
 
     /* 삽입 */
     public void insertDog(Dog dog) {
-        dogRepository.insertDog(dog);
+        Boolean isInserted = dogRepository.insertDog(dog);
+        if(!isInserted) {
+            throw new DogConflictException();
+        }
     }
 
     /* 조회 */
-    public Dog getDogByOwnerPhoneNumber(String ownerPhoneNumber) {
-        Dog dog = dogRepository.getDogByOwnerPhoneNumber(ownerPhoneNumber);
-        if(dog == null) {
+    public List<Dog> getDogByOwnerPhoneNumber(String ownerPhoneNumber) {
+        List<Dog> dogs = dogRepository.getDogByOwnerPhoneNumber(ownerPhoneNumber);
+        if(dogs == null) {
             throw new DogNotFoundException();
         }
-        return dog;
+        return dogs;
     }
 
     /* 수정 */


### PR DESCRIPTION
## 변경사항

- api호출을 dog에서 dogs로 경로 변경
  - REST API에서 자원은 복수여야하기 때문이다
- 강아지 생성 함수 추가
  - 이름/소유자이름/소유자번호가 중첩되지 않도록 필터링을 해줌
  - 강아지가 기존에 있다면 409에러 반환
- 강아지 주인번호로 조회 함수 변경
  - mongodb알고리즘 추가
  - 여러마리의 강아지가 반환될 수 있도록 변경
- 강아지 진료기록 추가 함수 변경
  - mongodb알고리즘 추가
  - 이름/소유자이름/소유자번호를 patch url에서 받아서 정확하게 강아지를 찾을 수 있도록 함